### PR TITLE
Adding in GlobalSetup and GlobalTeardown keys

### DIFF
--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -76,6 +76,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'collectCoverageFrom',
     'coverageReporters',
     'coverageThreshold',
+    'globalSetup',
+    'globalTeardown',
     'snapshotSerializers',
     'moduleNameMapper',
   ];


### PR DESCRIPTION
Allowing users to define Jest GlobalSetup and GlobalTeardown for testing.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
